### PR TITLE
Fix colon

### DIFF
--- a/_data/lectures.yml
+++ b/_data/lectures.yml
@@ -21,7 +21,7 @@
     - <a href="https://openreview.net/pdf?id=rylnK6VtDH">Multiplicative Interactions and Where to Find Them</a> <br/>
     - <a href="https://arxiv.org/abs/2112.12337">Cooperative Learning for Multi-view Analysis</a> <br/>
     - <a href="https://arxiv.org/abs/2109.04448">Vision-and-Language or Vision-for-Language? On Cross-Modal Influence in Multimodal Transformers</a> <br/>
-    - <a href="https://arxiv.org/abs/2012.12352">Seeing past words: Testing the cross-modal capabilities of pretrained V&L models on counting tasks</a> <br/>
+    - <a href="https://arxiv.org/abs/2012.12352"> Seeing past words&#58; Testing the cross-modal capabilities of pretrained V&L models on counting tasks</a> <br/>
 - date: 2/4
   title: >
     Week 3: <strong>Multimodal co-learning</strong>


### PR DESCRIPTION
Colons cause yaml parsing errors. This might fix it. https://stackoverflow.com/questions/11301650/how-to-escape-indicator-characters-i-e-or-in-yaml